### PR TITLE
Update fr translation for underline button in RichText component

### DIFF
--- a/packages/forms/resources/lang/fr/components.php
+++ b/packages/forms/resources/lang/fr/components.php
@@ -202,6 +202,7 @@ return [
             'ordered_list' => 'Nombres',
             'redo' => 'Refaire',
             'strike' => 'Barré',
+            'underline' => 'Souligné',
             'undo' => 'Annuler',
         ],
 


### PR DESCRIPTION
After v2.17.43 update, I update french components.php file to use new underline button in RichText field.